### PR TITLE
Match more resolver URL variants

### DIFF
--- a/crawl_doaj.rb
+++ b/crawl_doaj.rb
@@ -61,7 +61,7 @@ def makaleleriHazirla(i)
     doi = row.css("a")
     if doi != nil then
       doi.each do |doilink|
-        if doilink != nil and doilink.at("@href") != nil and doilink.at("@href").text.start_with?  "http://dx.doi" then
+        if doilink != nil and doilink.at("@href") != nil and doilink.at("@href").text.start_with?  /https?://(dx\.)?doi/ then
           makale += "<doi>"
           makale += doilink.text.strip
           makale += "</doi>"


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). I'm not sure whether DOAJ returns 100% old URLs, but in order to future-proof this code, how about switching to this reg-ex?

Cheers!